### PR TITLE
Removed function call to .unref() to fix errors.

### DIFF
--- a/lib/net/rpc-channel.js
+++ b/lib/net/rpc-channel.js
@@ -29,7 +29,7 @@ function RpcChannel(connection) {
     var self = this;
     setInterval(function () {
         executor.call(self);
-    }, 100).unref();
+    }, 100);
 }
 
 function executor() {


### PR DESCRIPTION
I always got error "unref is not a function" so I removed it. Works fine now.
