### PR TITLE
patch request-pq.js

### DIFF
--- a/lib/auth/request-pq.js
+++ b/lib/auth/request-pq.js
@@ -33,7 +33,7 @@ function requestPQ(callback, channel) {
         },
         channel: channel,
         callback: function (ex, resPQ) {
-            if (clientNonce === resPQ.nonce) {
+            if (resPQ && clientNonce === resPQ.nonce) {
                 var context = {
                     resPQ: resPQ,
                     channel: channel


### PR DESCRIPTION
This PR fixes this bug:

```
[ERROR] Tue, 29 Nov 2016 10:52:28 GMT  net.HttpConnection Error ECONNRESET
[ERROR] Tue, 29 Nov 2016 10:52:28 GMT  net.RpcChannel Unable to read: Error: read ECONNRESET 
/var/www/nodejs_projects/telegram_api/messengers_api/node_modules/telegram-mt-node/lib/auth/request-pq.js:36
            if (clientNonce === resPQ.nonce) {
                                     ^

TypeError: Cannot read property 'nonce' of undefined
    at mtproto.service.req_pq.callback (/var/www/nodejs_projects/telegram_api/messengers_api/node_modules/telegram-mt-node/lib/auth/request-pq.js:36:38)
    at /var/www/nodejs_projects/telegram_api/messengers_api/node_modules/telegram-mt-node/lib/net/rpc-channel.js:85:21
    at ClientRequest.onError (/var/www/nodejs_projects/telegram_api/messengers_api/node_modules/telegram-mt-node/lib/net/http-connection.js:134:13)
    at ClientRequest.g (events.js:286:16)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at Socket.socketErrorListener (_http_client.js:306:9)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at emitErrorNT (net.js:1272:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```